### PR TITLE
add log channel

### DIFF
--- a/nexus/src/globals.rs
+++ b/nexus/src/globals.rs
@@ -19,7 +19,7 @@ static IMGUI_CTX: OnceCell<ContextWrapper> = OnceCell::new();
 ///
 /// # Safety
 /// The passed pointer must be a valid [`AddonApi`] with `'static` lifetime.
-pub unsafe fn init(api: *const AddonApi) {
+pub unsafe fn init(api: *const AddonApi, log_channel: &'static str) {
     let api = api.as_ref().expect("no addon api supplied");
     ADDON_API
         .set(api)
@@ -27,12 +27,12 @@ pub unsafe fn init(api: *const AddonApi) {
 
     // panic hook
     panic::set_hook(Box::new(move |info| {
-        log(LogLevel::Critical, "file", format!("error: {info}"))
+        log(LogLevel::Critical, log_channel, format!("error: {info}"))
     }));
 
     // init logger
     #[cfg(feature = "log")]
-    NexusLogger::set_logger();
+    NexusLogger::set_logger(log_channel);
 
     // setup imgui
     imgui::sys::igSetCurrentContext(api.imgui_context);

--- a/nexus/src/logger.rs
+++ b/nexus/src/logger.rs
@@ -1,11 +1,12 @@
 use crate::log::{log as nexus_log, LogLevel};
 use log::Log;
 
-pub struct NexusLogger;
+pub struct NexusLogger(&'static str);
 
 impl NexusLogger {
-    pub fn set_logger() {
-        let _ = log::set_boxed_logger(Box::new(NexusLogger));
+    pub fn set_logger(channel: &'static str) {
+        let _ = log::set_boxed_logger(Box::new(NexusLogger(channel)));
+        log::set_max_level(log::LevelFilter::Trace);
     }
 }
 
@@ -15,12 +16,8 @@ impl Log for NexusLogger {
     }
 
     fn log(&self, record: &log::Record) {
-        let message = format!(
-            "{}: {}",
-            record.level().to_string().to_lowercase(),
-            record.args()
-        );
-        nexus_log(record.level().into(), "file", message)
+        let message = format!("{}", record.args());
+        nexus_log(record.level().into(), self.0, message)
     }
 
     fn flush(&self) {}

--- a/nexus_codegen/src/export.rs
+++ b/nexus_codegen/src/export.rs
@@ -73,8 +73,8 @@ impl AddonInfo {
 
     pub fn generate_export(&self) -> TokenStream {
         let signature = &self.signature;
-
-        let name = as_char_ptr(env_var("CARGO_PKG_NAME"));
+        let name = env_var("CARGO_PKG_NAME").to_token_stream();
+        let name_ptr = as_char_ptr(&name);
         let author = as_char_ptr(env_var("CARGO_PKG_AUTHORS"));
         let description = as_char_ptr(env_var("CARGO_PKG_DESCRIPTION"));
         let version = self.generate_version();
@@ -96,7 +96,7 @@ impl AddonInfo {
                 static ADDON_DEF: ::nexus::addon::AddonDefinition = ::nexus::addon::AddonDefinition {
                     signature: #signature,
                     api_version: ::nexus::api::API_VERSION,
-                    name: #name,
+                    name: #name_ptr,
                     version: #version,
                     author: #author,
                     description: #description,
@@ -113,7 +113,7 @@ impl AddonInfo {
                 }
 
                 unsafe extern "C-unwind" fn load_wrapper(api: *const ::nexus::api::AddonApi) {
-                    ::nexus::__macro::init(api);
+                    ::nexus::__macro::init(api, #name);
                     #load
                 }
 

--- a/nexus_example_addon/src/lib.rs
+++ b/nexus_example_addon/src/lib.rs
@@ -15,6 +15,7 @@ nexus::export! {
 
 fn load() {
     let mut show = false;
+    log::info!("Loading addon");
     register_render(RenderType::Render, move |ui| {
         Window::new("Test window").build(ui, || {
             if show {


### PR DESCRIPTION
This sets the log channel to the current crate name and removes some redundant information.

Loglines now look like this:

```rust
log::info!("Loading addon");
```
will produce:
`2024-03-20 14:02:54[nexus_example_addon]     [INFO] Loading addon`

ingame: 
![Gw2-64_2024-03-20_14-03-32](https://github.com/Zerthox/nexus-rs/assets/1449312/bbe5e500-ef25-4379-9642-1b5db70d3a9b)
