### PR TITLE
Add option to provide filters for logging

### DIFF
--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 authors = ["Zerthox"]
 description = "Rust bindings for Raidcore Nexus addons"

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -13,6 +13,7 @@ bitflags = "2.4.2"
 gw2_mumble = { git = "https://github.com/zerthox/gw2-mumble-rs", tag = "0.2.3", optional = true }
 imgui = { package = "arcdps-imgui", version = "0.8.0", features = [ "tables-api"] }
 log = { version = "0.4.21", features = ["std"], optional = true }
+env_filter = { version = "0.1.2", optional = true }
 nexus_codegen = { path = "../nexus_codegen" }
 num_enum = "0.7.2"
 paste = "1.0.14"
@@ -29,6 +30,7 @@ features = [
 ]
 
 [features]
+log = ["dep:log", "dep:env_filter"]
 arc = ["dep:arcdps"]
 arcdps = ["arc"]
 evtc = ["arc"]

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -30,7 +30,7 @@ features = [
 ]
 
 [features]
-log = ["dep:log", "dep:env_filter"]
+log = ["dep:log", "dep:env_filter", "nexus_codegen/env_filter"]
 arc = ["dep:arcdps"]
 arcdps = ["arc"]
 evtc = ["arc"]

--- a/nexus/src/api/v6.rs
+++ b/nexus/src/api/v6.rs
@@ -28,7 +28,7 @@ use super::{
     log::RawLog,
     paths::{RawGetAddonDir, RawGetCommonDir, RawGetGameDir},
     quick_access::{
-        RawQuickAccessAddContextMenu, RawQuickAccessAddShortcut, RawQuickAccessGeneric,
+        RawQuickAccessAddContextMenu2, RawQuickAccessAddShortcut, RawQuickAccessGeneric,
     },
     texture::{
         RawTextureGet, RawTextureGetOrCreateFromFile, RawTextureGetOrCreateFromMemory,
@@ -313,7 +313,7 @@ pub struct QuickAccessApi {
     pub notify: RawQuickAccessGeneric,
 
     /// Adds a new ImGui callback fired when right-clicking the shortcut icon.
-    pub add_context_menu: RawQuickAccessAddContextMenu,
+    pub add_context_menu: RawQuickAccessAddContextMenu2,
 
     /// Removes a registered context menu from the quick access item with the given identifier.
     pub remove_context_menu: RawQuickAccessGeneric,

--- a/nexus/src/globals.rs
+++ b/nexus/src/globals.rs
@@ -23,7 +23,11 @@ static IMGUI_UI: OnceLock<UiWrapper> = OnceLock::new();
 ///
 /// # Safety
 /// The passed pointer must be a valid [`AddonApi`] with `'static` lifetime.
-pub unsafe fn init(api: *const AddonApi, addon_name: &'static str) {
+pub unsafe fn init(
+    api: *const AddonApi,
+    addon_name: &'static str,
+    log_filter: Option<&'static str>,
+) {
     let api = api.as_ref().expect("no addon api supplied");
     ADDON_API
         .set(api)
@@ -36,7 +40,10 @@ pub unsafe fn init(api: *const AddonApi, addon_name: &'static str) {
 
     // init logger
     #[cfg(feature = "log")]
-    NexusLogger::set_logger(addon_name);
+    NexusLogger::set_logger(
+        addon_name,
+        log_filter.map(|lf| env_filter::Builder::new().parse(lf).build()),
+    );
 
     // setup imgui
     imgui::sys::igSetCurrentContext(api.imgui_context);

--- a/nexus/src/globals.rs
+++ b/nexus/src/globals.rs
@@ -26,7 +26,7 @@ static IMGUI_UI: OnceLock<UiWrapper> = OnceLock::new();
 pub unsafe fn init(
     api: *const AddonApi,
     addon_name: &'static str,
-    log_filter: Option<&'static str>,
+    #[cfg(feature = "log")] log_filter: Option<&'static str>,
 ) {
     let api = api.as_ref().expect("no addon api supplied");
     ADDON_API
@@ -40,10 +40,7 @@ pub unsafe fn init(
 
     // init logger
     #[cfg(feature = "log")]
-    NexusLogger::set_logger(
-        addon_name,
-        log_filter.map(|lf| env_filter::Builder::new().parse(lf).build()),
-    );
+    NexusLogger::set_logger(addon_name, log_filter);
 
     // setup imgui
     imgui::sys::igSetCurrentContext(api.imgui_context);

--- a/nexus/src/lib.rs
+++ b/nexus/src/lib.rs
@@ -71,6 +71,10 @@ pub struct SupportedFields {
 
     /// Link to the update resource.
     pub update_link: Option<&'static str>,
+
+    #[cfg(feature = "log")]
+    /// Filter for the log. Same syntax as [env_logger](https://docs.rs/env_logger/latest/env_logger/#enabling-logging).
+    pub log_filter: Option<&'static str>,
 }
 
 #[doc(hidden)]

--- a/nexus/src/logger.rs
+++ b/nexus/src/logger.rs
@@ -1,26 +1,34 @@
 use crate::log::{log as nexus_log, LogLevel};
+use env_filter::{Builder, Filter};
 use log::Log;
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct NexusLogger {
     channel_name: &'static str,
+    filter: Filter,
 }
 
 impl NexusLogger {
-    pub fn set_logger(channel_name: &'static str) {
-        let _ = log::set_boxed_logger(Box::new(NexusLogger { channel_name }));
+    pub fn set_logger(channel_name: &'static str, filter: Option<Filter>) {
+        let _ = log::set_boxed_logger(Box::new(NexusLogger {
+            channel_name,
+            filter: filter
+                .unwrap_or_else(|| Builder::new().filter_level(log::LevelFilter::Trace).build()),
+        }));
         log::set_max_level(log::LevelFilter::Trace);
     }
 }
 
 impl Log for NexusLogger {
-    fn enabled(&self, _metadata: &log::Metadata) -> bool {
-        true
+    fn enabled(&self, metadata: &log::Metadata) -> bool {
+        self.filter.enabled(metadata)
     }
 
     fn log(&self, record: &log::Record) {
-        let message = format!("{}", record.args());
-        nexus_log(record.level().into(), self.channel_name, message)
+        if self.filter.matches(record) {
+            let message = format!("{}", record.args());
+            nexus_log(record.level().into(), self.channel_name, message)
+        }
     }
 
     fn flush(&self) {}

--- a/nexus/src/logger.rs
+++ b/nexus/src/logger.rs
@@ -9,10 +9,11 @@ pub struct NexusLogger {
 }
 
 impl NexusLogger {
-    pub fn set_logger(channel_name: &'static str, filter: Option<Filter>) {
+    pub fn set_logger(channel_name: &'static str, filter: Option<&'static str>) {
         let _ = log::set_boxed_logger(Box::new(NexusLogger {
             channel_name,
             filter: filter
+                .map(|f| Builder::new().parse(f).build())
                 .unwrap_or_else(|| Builder::new().filter_level(log::LevelFilter::Trace).build()),
         }));
         log::set_max_level(log::LevelFilter::Trace);

--- a/nexus_codegen/Cargo.toml
+++ b/nexus_codegen/Cargo.toml
@@ -16,3 +16,7 @@ paste = "1.0.12"
 proc-macro2 = "1.0.56"
 quote = "1.0.26"
 syn = { version = "2.0.14", features = ["full"] }
+env_filter = { version = "0.1.2", optional = true }
+
+[features]
+env_filter = ["dep:env_filter"]

--- a/nexus_codegen/Cargo.toml
+++ b/nexus_codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus_codegen"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Zerthox"]
 description = "Helper macro to generate code for Raidcore Nexus addons"

--- a/nexus_codegen/src/addon.rs
+++ b/nexus_codegen/src/addon.rs
@@ -9,6 +9,7 @@ pub struct AddonInfo {
     pub flags: Option<Expr>,
     pub provider: Option<Expr>,
     pub update_link: Option<Expr>,
+    #[cfg(feature = "env_filter")]
     pub log_filter: Option<Expr>,
 }
 
@@ -33,7 +34,15 @@ impl AddonInfo {
                     "flags" => self.flags = Some(field.expr),
                     "provider" => self.provider = Some(field.expr),
                     "update_link" => self.update_link = Some(field.expr),
+                    #[cfg(feature = "env_filter")]
                     "log_filter" => self.log_filter = Some(field.expr),
+                    #[cfg(not(feature = "env_filter"))]
+                    "log_filter" => {
+                        return Err(Error::new_spanned(
+                            ident,
+                            "log_filter requires feature \"log\"",
+                        ))
+                    }
                     _ => return Err(Error::new_spanned(ident, "unknown field {ident}")),
                 }
             } else {
@@ -59,6 +68,7 @@ impl Default for AddonInfo {
             flags: None,
             provider: None,
             update_link: None,
+            #[cfg(feature = "env_filter")]
             log_filter: None,
         }
     }

--- a/nexus_codegen/src/addon.rs
+++ b/nexus_codegen/src/addon.rs
@@ -9,6 +9,7 @@ pub struct AddonInfo {
     pub flags: Option<Expr>,
     pub provider: Option<Expr>,
     pub update_link: Option<Expr>,
+    pub log_filter: Option<Expr>,
 }
 
 impl AddonInfo {
@@ -32,6 +33,7 @@ impl AddonInfo {
                     "flags" => self.flags = Some(field.expr),
                     "provider" => self.provider = Some(field.expr),
                     "update_link" => self.update_link = Some(field.expr),
+                    "log_filter" => self.log_filter = Some(field.expr),
                     _ => return Err(Error::new_spanned(ident, "unknown field {ident}")),
                 }
             } else {
@@ -57,6 +59,7 @@ impl Default for AddonInfo {
             flags: None,
             provider: None,
             update_link: None,
+            log_filter: None,
         }
     }
 }

--- a/nexus_codegen/src/export.rs
+++ b/nexus_codegen/src/export.rs
@@ -1,8 +1,12 @@
 use crate::addon::AddonInfo;
 use proc_macro2::TokenStream;
+#[cfg(feature = "env_filter")]
+use quote::quote_spanned;
 use quote::{quote, ToTokens};
 use std::env;
 use syn::Expr;
+#[cfg(feature = "env_filter")]
+use syn::{spanned::Spanned, Lit};
 
 fn env_var(key: &str) -> String {
     env::var(key).unwrap_or_else(|_| panic!("{key} not set"))
@@ -78,13 +82,30 @@ impl AddonInfo {
             .unwrap_or_else(|| quote! { ::std::ptr::null() })
     }
 
+    #[cfg(feature = "env_filter")]
     pub fn generate_log_filter(&self) -> TokenStream {
-        self.log_filter
+        return self
+            .log_filter
             .as_ref()
             .map(|e| {
-                quote! { ::std::option::Option::Some(#e) }
+                if let Expr::Lit(lit) = e {
+                    if let Lit::Str(ref lit) = lit.lit {
+                        match env_filter::Builder::new().try_parse(&lit.value()) {
+                            Ok(_filter) => return quote! { ::std::option::Option::Some(#e) },
+                            Err(err) => {
+                                let err = format!("{}", err);
+                                return quote_spanned! {
+                                    e.span() => compile_error!(concat!("invalid log filter: ", #err)),
+                                };
+                            }
+                        }
+                    }
+                }
+                return quote_spanned! {
+                    e.span() => compile_error!("Only string literals allowed in log filter"),
+                };
             })
-            .unwrap_or_else(|| quote! { ::std::option::Option::None })
+            .unwrap_or_else(|| quote! { ::std::option::Option::None });
     }
 
     pub fn generate_export(&self) -> TokenStream {
@@ -94,7 +115,13 @@ impl AddonInfo {
         let author = as_char_ptr(env_var("CARGO_PKG_AUTHORS"));
         let description = as_char_ptr(env_var("CARGO_PKG_DESCRIPTION"));
         let version = self.generate_version();
-        let log_filter = self.generate_log_filter();
+        #[cfg(feature = "env_filter")]
+        let initfn = {
+            let log_filter = self.generate_log_filter();
+            quote! { ::nexus::__macro::init(api, self::__ADDON_NAME, #log_filter); }
+        };
+        #[cfg(not(feature = "env_filter"))]
+        let initfn = quote! { ::nexus::__macro::init(api, self::__ADDON_NAME);};
 
         let load = self.generate_load();
         let unload = self.generate_unload();
@@ -132,7 +159,7 @@ impl AddonInfo {
                 }
 
                 unsafe extern "C-unwind" fn __load_wrapper(api: *const ::nexus::AddonApi) {
-                    ::nexus::__macro::init(api, self::__ADDON_NAME, #log_filter);
+                    #initfn
                     #load
                 }
 

--- a/nexus_codegen/src/export.rs
+++ b/nexus_codegen/src/export.rs
@@ -101,9 +101,9 @@ impl AddonInfo {
                         }
                     }
                 }
-                return quote_spanned! {
+                quote_spanned! {
                     e.span() => compile_error!("Only string literals allowed in log filter"),
-                };
+                }
             })
             .unwrap_or_else(|| quote! { ::std::option::Option::None });
     }

--- a/nexus_codegen/src/export.rs
+++ b/nexus_codegen/src/export.rs
@@ -78,6 +78,15 @@ impl AddonInfo {
             .unwrap_or_else(|| quote! { ::std::ptr::null() })
     }
 
+    pub fn generate_log_filter(&self) -> TokenStream {
+        self.log_filter
+            .as_ref()
+            .map(|e| {
+                quote! { ::std::option::Option::Some(#e) }
+            })
+            .unwrap_or_else(|| quote! { ::std::option::Option::None })
+    }
+
     pub fn generate_export(&self) -> TokenStream {
         let signature = &self.signature;
         let name = self.generate_name();
@@ -85,6 +94,7 @@ impl AddonInfo {
         let author = as_char_ptr(env_var("CARGO_PKG_AUTHORS"));
         let description = as_char_ptr(env_var("CARGO_PKG_DESCRIPTION"));
         let version = self.generate_version();
+        let log_filter = self.generate_log_filter();
 
         let load = self.generate_load();
         let unload = self.generate_unload();
@@ -122,7 +132,7 @@ impl AddonInfo {
                 }
 
                 unsafe extern "C-unwind" fn __load_wrapper(api: *const ::nexus::AddonApi) {
-                    ::nexus::__macro::init(api, self::__ADDON_NAME);
+                    ::nexus::__macro::init(api, self::__ADDON_NAME, #log_filter);
                     #load
                 }
 

--- a/nexus_example_addon/src/lib.rs
+++ b/nexus_example_addon/src/lib.rs
@@ -18,6 +18,7 @@ nexus::export! {
     flags: AddonFlags::None,
     provider: UpdateProvider::GitHub,
     update_link: "https://github.com/zerthox/nexus-rs",
+    log_filter: "debug"
 }
 
 fn load() {


### PR DESCRIPTION
This allows configuring the logger.

Usecase: Configuring log levels of dependencies

Default is still `Trace` level logging