### PR TITLE
Fix rtapi PlayerData character name

### DIFF
--- a/nexus/src/api/rtapi/player.rs
+++ b/nexus/src/api/rtapi/player.rs
@@ -41,7 +41,7 @@ impl PlayerData {
                 account_name: CStr::from_ptr((*data).account_name.as_ptr())
                     .to_string_lossy()
                     .into_owned(),
-                character_name: CStr::from_ptr((*data).account_name.as_ptr())
+                character_name: CStr::from_ptr((*data).character_name.as_ptr())
                     .to_string_lossy()
                     .into_owned(),
                 character_position: (*data).character_position,


### PR DESCRIPTION
Small fix to rtapi bindings. The player `character_name` field was getting the account name instead.